### PR TITLE
Refactor and Improve Vesting Contract Test Suite

### DIFF
--- a/contracts/BaseVestingToken.sol
+++ b/contracts/BaseVestingToken.sol
@@ -381,8 +381,11 @@ abstract contract BaseVestingToken is
         if (vestedInstallments == schedule.installmentCount) {
             totalVestedAmount = schedule.totalAmount;
         } else {
-            uint256 vestedProportionNumerator = schedule.totalAmount * vestedInstallments;
-            totalVestedAmount = vestedProportionNumerator / schedule.installmentCount;
+            uint256 vestedProportionNumerator = schedule.totalAmount *
+                vestedInstallments;
+            totalVestedAmount =
+                vestedProportionNumerator /
+                schedule.installmentCount;
         }
 
         return totalVestedAmount - schedule.releasedAmount;

--- a/contracts/mocks/MockVestingToken.sol
+++ b/contracts/mocks/MockVestingToken.sol
@@ -10,16 +10,26 @@ import "../BaseVestingToken.sol";
  * @dev This contract inherits from BaseVestingToken and provides a simplified vesting schedule creation for testing.
  */
 contract MockVestingToken is BaseVestingToken {
+    uint256 public immutable cliffDurationInDays;
+    uint256 public immutable vestingDurationInDays;
+    uint256 public immutable installmentCount;
+
     /**
      * @dev Sets up the contract with initial parameters for the mock vesting token.
      * @param initialOwner The initial owner of the contract.
      * @param initialDistributorManager The initial distributor manager.
      * @param amdTokenAddress The address of the AMD token.
+     * @param _cliffDurationInDays The cliff duration in days.
+     * @param _vestingDurationInDays The total vesting duration in days.
+     * @param _installmentCount The number of installments.
      */
     constructor(
         address initialOwner,
         address initialDistributorManager,
-        address amdTokenAddress
+        address amdTokenAddress,
+        uint256 _cliffDurationInDays,
+        uint256 _vestingDurationInDays,
+        uint256 _installmentCount
     )
         BaseVestingToken(
             "MockVestingToken",
@@ -29,10 +39,14 @@ contract MockVestingToken is BaseVestingToken {
             amdTokenAddress,
             1000000000 * (10 ** 18)
         )
-    {}
+    {
+        cliffDurationInDays = _cliffDurationInDays;
+        vestingDurationInDays = _vestingDurationInDays;
+        installmentCount = _installmentCount;
+    }
 
     /**
-     * @notice Creates a vesting schedule for a beneficiary with a mock schedule.
+     * @notice Creates a vesting schedule for a beneficiary with the mock schedule.
      * @dev Can only be called by an address with the DISTRIBUTOR_ROLE.
      * @param beneficiary The address of the beneficiary.
      * @param totalAmount The total amount of tokens to be vested.
@@ -46,14 +60,10 @@ contract MockVestingToken is BaseVestingToken {
             "Insufficient balance for vesting"
         );
 
-        uint256 cliffDuration = 1 minutes;
-        uint256 vestingDuration = 11 minutes;
-        uint256 installmentCount = 10;
-
         _createVestingSchedule(
             beneficiary,
-            cliffDuration,
-            vestingDuration,
+            cliffDurationInDays,
+            vestingDurationInDays,
             installmentCount,
             totalAmount
         );

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "hardhat test",
-    "test:inv": "hardhat test test/InvestorVesting.test.ts",
-    "test:fnd": "hardhat test test/FounderVesting.test.ts",
-    "test:emp": "hardhat test test/EmployeeVesting.test.ts",
+    "test:inv": "hardhat test test/InvestorVestingToken.test.ts",
+    "test:fnd": "hardhat test test/FounderVestingToken.test.ts",
+    "test:emp": "hardhat test test/EmployeeVestingToken.test.ts",
     "test:mock": "hardhat test test/MockVestingToken.test.ts",
     "build": "hardhat compile",
     "localnode": "NODE_OPTIONS='--max-old-space-size=8192' yarn hardhat node --port 8545",

--- a/scripts/mocks/deploy-mock-vesting-token.ts
+++ b/scripts/mocks/deploy-mock-vesting-token.ts
@@ -45,7 +45,10 @@ async function main() {
   const mockVestingToken = await ethers.deployContract("MockVestingToken", [
     initialOwner,
     initialDistributorManager,
-    aimondTokenAddress
+    aimondTokenAddress,
+    1, // cliffDurationInDays
+    11, // vestingDurationInDays
+    10  // installmentCount
   ]);
   await mockVestingToken.waitForDeployment();
 

--- a/test/AccessControl.test.ts
+++ b/test/AccessControl.test.ts
@@ -3,9 +3,9 @@ import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { EmployeeVestingToken, AimondToken } from "../typechain-types";
 
-describe("BaseVestingToken AccessControl", function () {
-    let BaseVestingToken: EmployeeVestingToken;
-    let AimondToken: AimondToken;
+describe("EmployeeVestingToken AccessControl", function () {
+    let empVestingToken: EmployeeVestingToken;
+    let aimondToken: AimondToken;
     let owner: SignerWithAddress;
     let initialDistributorManager: SignerWithAddress;
     let addr2: SignerWithAddress;
@@ -20,91 +20,91 @@ describe("BaseVestingToken AccessControl", function () {
         [owner, initialDistributorManager, addr2, addr3, ...addrs] = await ethers.getSigners();
 
         const AimondTokenFactory = await ethers.getContractFactory("AimondToken");
-        AimondToken = await AimondTokenFactory.deploy(owner.address);
-        await AimondToken.waitForDeployment();
+        aimondToken = await AimondTokenFactory.deploy(owner.address);
+        await aimondToken.waitForDeployment();
 
         const EmployeeVestingTokenFactory = await ethers.getContractFactory("EmployeeVestingToken");
-        BaseVestingToken = await EmployeeVestingTokenFactory.deploy(
+        empVestingToken = await EmployeeVestingTokenFactory.deploy(
             owner.address,
             initialDistributorManager.address,
-            AimondToken.target
+            aimondToken.target
         );
-        await BaseVestingToken.waitForDeployment();
+        await empVestingToken.waitForDeployment();
     });
 
     describe("Role Assignments on Deployment", function () {
         it("Should grant DEFAULT_ADMIN_ROLE to the initialOwner", async function () {
-            expect(await BaseVestingToken.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).to.be.true;
         });
 
         it("Should grant DISTRIBUTOR_MANAGER_ROLE to initialOwner and initialDistributorManager", async function () {
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, owner.address)).to.be.true;
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, initialDistributorManager.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, owner.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, initialDistributorManager.address)).to.be.true;
         });
 
         it("Should grant DISTRIBUTOR_ROLE to initialOwner and initialDistributorManager", async function () {
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_ROLE, owner.address)).to.be.true;
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_ROLE, initialDistributorManager.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_ROLE, owner.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_ROLE, initialDistributorManager.address)).to.be.true;
         });
     });
 
     describe("Distributor Manager Management", function () {
         it("Should allow DEFAULT_ADMIN_ROLE to add a new distributor manager", async function () {
-            await expect(BaseVestingToken.connect(owner).addDistributorManager(addr2.address))
-                .to.emit(BaseVestingToken, "RoleGranted")
+            await expect(empVestingToken.connect(owner).addDistributorManager(addr2.address))
+                .to.emit(empVestingToken, "RoleGranted")
                 .withArgs(DISTRIBUTOR_MANAGER_ROLE, addr2.address, owner.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.true;
         });
 
         it("Should allow DEFAULT_ADMIN_ROLE to remove a distributor manager", async function () {
-            await BaseVestingToken.connect(owner).addDistributorManager(addr2.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.true;
+            await empVestingToken.connect(owner).addDistributorManager(addr2.address);
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.true;
 
-            await expect(BaseVestingToken.connect(owner).removeDistributorManager(addr2.address))
-                .to.emit(BaseVestingToken, "RoleRevoked")
+            await expect(empVestingToken.connect(owner).removeDistributorManager(addr2.address))
+                .to.emit(empVestingToken, "RoleRevoked")
                 .withArgs(DISTRIBUTOR_MANAGER_ROLE, addr2.address, owner.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.false;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_MANAGER_ROLE, addr2.address)).to.be.false;
         });
 
         it("Should not allow non-admin to add or remove a distributor manager", async function () {
-            await expect(BaseVestingToken.connect(initialDistributorManager).addDistributorManager(addr2.address))
-                .to.be.revertedWithCustomError(BaseVestingToken, "AccessControlUnauthorizedAccount")
+            await expect(empVestingToken.connect(initialDistributorManager).addDistributorManager(addr2.address))
+                .to.be.revertedWithCustomError(empVestingToken, "AccessControlUnauthorizedAccount")
                 .withArgs(initialDistributorManager.address, DEFAULT_ADMIN_ROLE);
 
-            await expect(BaseVestingToken.connect(initialDistributorManager).removeDistributorManager(owner.address))
-                .to.be.revertedWithCustomError(BaseVestingToken, "AccessControlUnauthorizedAccount")
+            await expect(empVestingToken.connect(initialDistributorManager).removeDistributorManager(owner.address))
+                .to.be.revertedWithCustomError(empVestingToken, "AccessControlUnauthorizedAccount")
                 .withArgs(initialDistributorManager.address, DEFAULT_ADMIN_ROLE);
         });
     });
 
     describe("Distributor Management", function () {
         it("Should allow DISTRIBUTOR_MANAGER_ROLE to add a distributor", async function () {
-            await expect(BaseVestingToken.connect(initialDistributorManager).addDistributor(addr2.address))
-                .to.emit(BaseVestingToken, "DistributorAdded")
+            await expect(empVestingToken.connect(initialDistributorManager).addDistributor(addr2.address))
+                .to.emit(empVestingToken, "DistributorAdded")
                 .withArgs(addr2.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.true;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.true;
         });
 
         it("Should not allow non-DISTRIBUTOR_MANAGER_ROLE to add a distributor", async function () {
-            await expect(BaseVestingToken.connect(addr2).addDistributor(addr3.address))
-                .to.be.revertedWithCustomError(BaseVestingToken, "AccessControlUnauthorizedAccount")
+            await expect(empVestingToken.connect(addr2).addDistributor(addr3.address))
+                .to.be.revertedWithCustomError(empVestingToken, "AccessControlUnauthorizedAccount")
                 .withArgs(addr2.address, DISTRIBUTOR_MANAGER_ROLE);
         });
 
         it("Should allow DISTRIBUTOR_MANAGER_ROLE to remove a distributor", async function () {
-            await BaseVestingToken.connect(initialDistributorManager).addDistributor(addr2.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.true;
+            await empVestingToken.connect(initialDistributorManager).addDistributor(addr2.address);
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.true;
 
-            await expect(BaseVestingToken.connect(initialDistributorManager).removeDistributor(addr2.address))
-                .to.emit(BaseVestingToken, "DistributorRemoved")
+            await expect(empVestingToken.connect(initialDistributorManager).removeDistributor(addr2.address))
+                .to.emit(empVestingToken, "DistributorRemoved")
                 .withArgs(addr2.address);
-            expect(await BaseVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.false;
+            expect(await empVestingToken.hasRole(DISTRIBUTOR_ROLE, addr2.address)).to.be.false;
         });
 
         it("Should not allow non-DISTRIBUTOR_MANAGER_ROLE to remove a distributor", async function () {
-            await BaseVestingToken.connect(initialDistributorManager).addDistributor(addr2.address);
-            await expect(BaseVestingToken.connect(addr3).removeDistributor(addr2.address))
-                .to.be.revertedWithCustomError(BaseVestingToken, "AccessControlUnauthorizedAccount")
+            await empVestingToken.connect(initialDistributorManager).addDistributor(addr2.address);
+            await expect(empVestingToken.connect(addr3).removeDistributor(addr2.address))
+                .to.be.revertedWithCustomError(empVestingToken, "AccessControlUnauthorizedAccount")
                 .withArgs(addr3.address, DISTRIBUTOR_MANAGER_ROLE);
         });
     });

--- a/test/EmployeeVestingToken.test.ts
+++ b/test/EmployeeVestingToken.test.ts
@@ -6,6 +6,8 @@ import * as helpers from "@nomicfoundation/hardhat-network-helpers";
 
 import { formatTimestamp, formatAmdBalance, formatAimBalance } from "./utils/time";
 
+import { TOTAL_VESTING_AMOUNT_EMPLOYEE } from "./constants";
+
 describe("EmployeeVestingToken Scenarios", function () {
     async function deployVestingFixture() {
         const [owner, beneficiary] = await ethers.getSigners();
@@ -20,7 +22,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         await vestingContract.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = ethers.parseUnits("100000", 18); // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE; // Example total amount for vesting
         await amdToken.connect(owner).transfer(await vestingContract.getAddress(), totalAmdForVesting);
 
         return { vestingContract, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -45,6 +47,8 @@ describe("EmployeeVestingToken Scenarios", function () {
         const initialBalance = await amdToken.balanceOf(beneficiary.address);
         console.log("Partner AMD Initaial Balance:", formatAmdBalance(initialBalance));
 
+        // IMPORTANT: There is a 1-second offset with `helpers.time.increaseTo`.
+        // Calling `increaseTo(T)` results in the next block having a timestamp of `T + 1`.
         await helpers.time.increaseTo(twoSecBeforeCliffEnds);
         console.log("Current Block Timestamp (before claim):", formatTimestamp(Number(await helpers.time.latest())), `(${await helpers.time.latest()})`);
         
@@ -109,7 +113,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         
         const schedule = await vestingContract.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingContract.globalStartTime();
-        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(schedule.releaseDuration);
+        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.totalVestingDuration);
         
         console.log("Full Vesting Ends Timestamp:", formatTimestamp(Number(fullVestingEndsTimestamp)), `(${fullVestingEndsTimestamp})`);
 
@@ -161,7 +165,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20000", 18);
         await vestingContract.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingContract.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-        const totalAmdForVesting = ethers.parseUnits("100000", 18);
+                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE;
         await amdToken
             .connect(owner)
             .transfer(await vestingContract.getAddress(), totalAmdForVesting);
@@ -181,8 +185,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         const globalStartTime = await vestingContract.globalStartTime();
         const fullVestingEndsTimestamp =
             Number(globalStartTime) +
-            Number(schedule.cliffDuration) +
-            Number(schedule.releaseDuration);
+            Number(schedule.totalVestingDuration);
 
         await helpers.time.increaseTo(fullVestingEndsTimestamp);
         await vestingContract

--- a/test/FounderVestingToken.test.ts
+++ b/test/FounderVestingToken.test.ts
@@ -6,6 +6,8 @@ import * as helpers from "@nomicfoundation/hardhat-network-helpers";
 
 import { formatTimestamp, formatAmdBalance, formatAimBalance } from "./utils/time";
 
+import { TOTAL_VESTING_AMOUNT_FOUNDER } from "./constants";
+
 describe("FounderVestingToken Scenarios", function () {
     async function deployVestingFixture() {
         const [owner, beneficiary] = await ethers.getSigners();
@@ -20,7 +22,7 @@ describe("FounderVestingToken Scenarios", function () {
         await vestingToken.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = ethers.parseUnits("100000", 18); // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER; // Example total amount for vesting
         await amdToken.connect(owner).transfer(await vestingToken.getAddress(), totalAmdForVesting);
 
         return { vestingToken, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -45,6 +47,8 @@ describe("FounderVestingToken Scenarios", function () {
         const initialBalance = await amdToken.balanceOf(beneficiary.address);
         console.log("Founder AMD Initaial Balance:", formatAmdBalance(initialBalance));
 
+        // IMPORTANT: There is a 1-second offset with `helpers.time.increaseTo`.
+        // Calling `increaseTo(T)` results in the next block having a timestamp of `T + 1`.
         await helpers.time.increaseTo(twoSecBeforeCliffEnds);
         console.log("Current Block Timestamp (before claim):", formatTimestamp(Number(await helpers.time.latest())), `(${await helpers.time.latest()})`);
         
@@ -111,7 +115,7 @@ describe("FounderVestingToken Scenarios", function () {
         
         const schedule = await vestingToken.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingToken.globalStartTime();
-        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(schedule.releaseDuration);
+        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.totalVestingDuration);
         
         console.log("Full Vesting Ends Timestamp:", formatTimestamp(Number(fullVestingEndsTimestamp)), `(${fullVestingEndsTimestamp})`);
 
@@ -163,7 +167,7 @@ describe("FounderVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20000", 18);
         await vestingToken.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingToken.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-        const totalAmdForVesting = ethers.parseUnits("100000", 18);
+                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER;
         await amdToken
             .connect(owner)
             .transfer(await vestingToken.getAddress(), totalAmdForVesting);
@@ -183,8 +187,7 @@ describe("FounderVestingToken Scenarios", function () {
         const globalStartTime = await vestingToken.globalStartTime();
         const fullVestingEndsTimestamp =
             Number(globalStartTime) +
-            Number(schedule.cliffDuration) +
-            Number(schedule.releaseDuration);
+            Number(schedule.totalVestingDuration);
 
         await helpers.time.increaseTo(fullVestingEndsTimestamp);
         await vestingToken

--- a/test/InvestorVestingToken.test.ts
+++ b/test/InvestorVestingToken.test.ts
@@ -6,6 +6,8 @@ import * as helpers from "@nomicfoundation/hardhat-network-helpers";
 
 import { formatTimestamp, formatAmdBalance, formatAimBalance } from "./utils/time";
 
+import { TOTAL_VESTING_AMOUNT_INVESTOR } from "./constants";
+
 describe("InvestorVestingToken Scenarios", function () {
     async function deployVestingFixture() {
         const [owner, beneficiary] = await ethers.getSigners();
@@ -20,7 +22,7 @@ describe("InvestorVestingToken Scenarios", function () {
         await vestingToken.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = ethers.parseUnits("100000", 18); // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR; // Example total amount for vesting
         await amdToken.connect(owner).transfer(await vestingToken.getAddress(), totalAmdForVesting);
 
         return { vestingToken, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -45,6 +47,10 @@ describe("InvestorVestingToken Scenarios", function () {
         const initialBalance = await amdToken.balanceOf(beneficiary.address);
         console.log("Investor AMD Initaial Balance:", formatAmdBalance(initialBalance));
 
+        // IMPORTANT: There is a 1-second offset with `helpers.time.increaseTo`.
+        // Calling `increaseTo(T)` results in the next block having a timestamp of `T + 1`.
+        // To test the state *before* the cliff ends, we must jump to at least 2 seconds before.
+        // Jumping to `cliffEndsTimestamp - 2` ensures the claim transaction occurs at `cliffEndsTimestamp - 1`.
         await helpers.time.increaseTo(twoSecBeforeCliffEnds);
         console.log("Current Block Timestamp (before claim):", formatTimestamp(Number(await helpers.time.latest())), `(${await helpers.time.latest()})`);
         
@@ -111,7 +117,7 @@ describe("InvestorVestingToken Scenarios", function () {
         
         const schedule = await vestingToken.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingToken.globalStartTime();
-        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(schedule.releaseDuration);
+        const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.totalVestingDuration);
         
         console.log("Full Vesting Ends Timestamp:", formatTimestamp(Number(fullVestingEndsTimestamp)), `(${fullVestingEndsTimestamp})`);
 
@@ -124,7 +130,7 @@ describe("InvestorVestingToken Scenarios", function () {
     });
 
     it("Should release tokens correctly over each installment", async function () {
-        const { vestingToken, amdToken, owner, beneficiary, scheduleAmount, amdDecimals } = await helpers.loadFixture(deployVestingFixture);
+        const { vestingToken, amdToken, owner, beneficiary, scheduleAmount } = await helpers.loadFixture(deployVestingFixture);
 
         await vestingToken.connect(owner).createVesting(beneficiary.address, scheduleAmount);
         await vestingToken.connect(owner).setGlobalStartTime(await helpers.time.latest());
@@ -142,6 +148,7 @@ describe("InvestorVestingToken Scenarios", function () {
             const newTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(installmentDuration) * i - 1;
             console.log("New installment:", formatTimestamp(Number(newTimestamp)), `(${newTimestamp})`);
         
+            // Note: `increaseTo(T)` results in the next block timestamp being `T + 1`.
             await helpers.time.increaseTo(newTimestamp);
             await vestingToken.connect(beneficiary).claim();
 
@@ -163,7 +170,7 @@ describe("InvestorVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20002", 18);
         await vestingToken.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingToken.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-        const totalAmdForVesting = ethers.parseUnits("100000", 18);
+                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR;
         await amdToken
             .connect(owner)
             .transfer(await vestingToken.getAddress(), totalAmdForVesting);
@@ -183,8 +190,7 @@ describe("InvestorVestingToken Scenarios", function () {
         const globalStartTime = await vestingToken.globalStartTime();
         const fullVestingEndsTimestamp =
             Number(globalStartTime) +
-            Number(schedule.cliffDuration) +
-            Number(schedule.releaseDuration);
+            Number(schedule.totalVestingDuration);
 
         await helpers.time.increaseTo(fullVestingEndsTimestamp);
         await vestingToken

--- a/test/InvestorVestingToken.test.ts
+++ b/test/InvestorVestingToken.test.ts
@@ -18,7 +18,6 @@ describe("InvestorVestingToken Scenarios", function () {
 
         // Transfer VestingToken to beneficiary
         const scheduleAmount = ethers.parseUnits("10001", 18);
-        console.log("Schedule Amount:", formatAimBalance(scheduleAmount));
         await vestingToken.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
@@ -32,33 +31,26 @@ describe("InvestorVestingToken Scenarios", function () {
         const { vestingToken, amdToken, owner, beneficiary, scheduleAmount } = await helpers.loadFixture(deployVestingFixture);
 
         const listingTimestamp = await helpers.time.latest();
-        console.log("Investor Listing Timestamp:", formatTimestamp(Number(listingTimestamp)), `(${listingTimestamp})`);
         await vestingToken.connect(owner).createVesting(beneficiary.address, scheduleAmount);
         await vestingToken.connect(owner).setGlobalStartTime(listingTimestamp);
         
         const schedule = await vestingToken.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingToken.globalStartTime();
-        console.log("Global Start Time:", formatTimestamp(Number(globalStartTime)), `(${globalStartTime})`);
-        console.log("Schedule Cliff Duration:", schedule.cliffDuration.toString());
         const cliffEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration);
         const twoSecBeforeCliffEnds = cliffEndsTimestamp - 2;
-        console.log("2 Sec Before Cliff Ends Timestamp:", formatTimestamp(Number(twoSecBeforeCliffEnds)), `(${twoSecBeforeCliffEnds})`);
 
         const initialBalance = await amdToken.balanceOf(beneficiary.address);
-        console.log("Investor AMD Initaial Balance:", formatAmdBalance(initialBalance));
 
         // IMPORTANT: There is a 1-second offset with `helpers.time.increaseTo`.
         // Calling `increaseTo(T)` results in the next block having a timestamp of `T + 1`.
         // To test the state *before* the cliff ends, we must jump to at least 2 seconds before.
         // Jumping to `cliffEndsTimestamp - 2` ensures the claim transaction occurs at `cliffEndsTimestamp - 1`.
         await helpers.time.increaseTo(twoSecBeforeCliffEnds);
-        console.log("Current Block Timestamp (before claim):", formatTimestamp(Number(await helpers.time.latest())), `(${await helpers.time.latest()})`);
         
         const releasableAmount = await vestingToken.getCurrentlyReleasableAmount(beneficiary.address);
         expect(releasableAmount).to.equal(0);
 
         await vestingToken.connect(beneficiary).claim();
-        console.log("Investor AMD Balance (Before Cliff Claim):", formatAmdBalance(await amdToken.balanceOf(beneficiary.address)));
         expect(await amdToken.balanceOf(beneficiary.address)).to.equal(initialBalance);
     });
 
@@ -66,22 +58,17 @@ describe("InvestorVestingToken Scenarios", function () {
         const { vestingToken, amdToken, owner, beneficiary, scheduleAmount } = await helpers.loadFixture(deployVestingFixture);
 
         const listingTimestamp = await helpers.time.latest();
-        console.log("Investor Listing Timestamp:", formatTimestamp(Number(listingTimestamp)), `(${listingTimestamp})`);
         await vestingToken.connect(owner).createVesting(beneficiary.address, scheduleAmount);
         await vestingToken.connect(owner).setGlobalStartTime(listingTimestamp);
         
         const schedule = await vestingToken.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingToken.globalStartTime();
-        console.log("Global Start Time:", formatTimestamp(Number(globalStartTime)), `(${globalStartTime})`);
         const cliffEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) - 1;
-        console.log("Cliff Ends Timestamp:", formatTimestamp(Number(cliffEndsTimestamp)), `(${cliffEndsTimestamp})`);
 
         await helpers.time.increaseTo(cliffEndsTimestamp); // one sec before cliff end
-        console.log("Investor Claim Time (After Cliff):", formatTimestamp(await helpers.time.latest()), `(${await helpers.time.latest()})`);
         await vestingToken.connect(beneficiary).claim();
 
         const expectedAmount = scheduleAmount / schedule.installmentCount;
-        console.log("Investor AMD Balance (after cliff claim):", formatAmdBalance(await amdToken.balanceOf(beneficiary.address)));
         expect(await amdToken.balanceOf(beneficiary.address)).to.equal(expectedAmount);
     });
 
@@ -89,22 +76,17 @@ describe("InvestorVestingToken Scenarios", function () {
         const { vestingToken, amdToken, owner, beneficiary, scheduleAmount } = await helpers.loadFixture(deployVestingFixture);
 
         const listingTimestamp = await helpers.time.latest();
-        console.log("Investor Listing Timestamp:", formatTimestamp(Number(listingTimestamp)), `(${listingTimestamp})`);
         await vestingToken.connect(owner).createVesting(beneficiary.address, scheduleAmount);
         await vestingToken.connect(owner).setGlobalStartTime(listingTimestamp);
         
         const schedule = await vestingToken.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingToken.globalStartTime();
-        console.log("Global Start Time:", formatTimestamp(Number(globalStartTime)), `(${globalStartTime})`);
         const cliffEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration);
-        console.log("Cliff Ends Timestamp:", formatTimestamp(Number(cliffEndsTimestamp)), `(${cliffEndsTimestamp})`);
 
         await helpers.time.increaseTo(cliffEndsTimestamp); // Exactly at cliff end
-        console.log("Investor Claim Time (After Cliff):", formatTimestamp(await helpers.time.latest()), `(${await helpers.time.latest()})`);
         await vestingToken.connect(beneficiary).claim();
 
         const expectedAmount = scheduleAmount / schedule.installmentCount;
-        console.log("Investor AMD Balance (after cliff claim):", formatAmdBalance(await amdToken.balanceOf(beneficiary.address)));
         expect(await amdToken.balanceOf(beneficiary.address)).to.equal(expectedAmount);
     });
 
@@ -119,13 +101,10 @@ describe("InvestorVestingToken Scenarios", function () {
         const globalStartTime = await vestingToken.globalStartTime();
         const fullVestingEndsTimestamp = Number(globalStartTime) + Number(schedule.totalVestingDuration);
         
-        console.log("Full Vesting Ends Timestamp:", formatTimestamp(Number(fullVestingEndsTimestamp)), `(${fullVestingEndsTimestamp})`);
 
         await helpers.time.increaseTo(fullVestingEndsTimestamp);
-        console.log("Investor Claim Time (After Full Vesting):", formatTimestamp(await helpers.time.latest()), `(${await helpers.time.latest()})`);
         await vestingToken.connect(beneficiary).claim();
 
-        console.log("Investor AMD Balance (after full vesting claim):", formatAmdBalance(await amdToken.balanceOf(beneficiary.address)));
         expect(await amdToken.balanceOf(beneficiary.address)).to.equal(scheduleAmount);
     });
 
@@ -146,14 +125,12 @@ describe("InvestorVestingToken Scenarios", function () {
 
         for (let i = 0; i < schedule.installmentCount; i++) {
             const newTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(installmentDuration) * i - 1;
-            console.log("New installment:", formatTimestamp(Number(newTimestamp)), `(${newTimestamp})`);
         
             // Note: `increaseTo(T)` results in the next block timestamp being `T + 1`.
             await helpers.time.increaseTo(newTimestamp);
             await vestingToken.connect(beneficiary).claim();
 
             totalClaimedAmd += expectedAmount;
-            console.log("Investor AMD Balance (after installment):", formatAmdBalance(await amdToken.balanceOf(beneficiary.address)));
             expect(await amdToken.balanceOf(beneficiary.address)).to.equal(totalClaimedAmd);
         }
     });

--- a/test/MockVestingToken.test.ts
+++ b/test/MockVestingToken.test.ts
@@ -1,4 +1,3 @@
-
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";

--- a/test/MockVestingToken.test.ts
+++ b/test/MockVestingToken.test.ts
@@ -8,7 +8,7 @@ describe("MockVestingToken Scenarios", function () {
     async function deployVestingFixture() {
         const [owner, beneficiary] = await ethers.getSigners();
         const amdToken = await ethers.deployContract("AimondToken", [owner.address]);
-        const vestingContract = await ethers.deployContract("MockVestingToken", [owner.address, owner.address, await amdToken.getAddress()]);
+        const vestingContract = await ethers.deployContract("MockVestingToken", [owner.address, owner.address, await amdToken.getAddress(), 1, 11, 10]);
 
         const scheduleAmount = ethers.parseUnits("1000", 18);
         await vestingContract.connect(owner).transfer(beneficiary.address, scheduleAmount);

--- a/test/MockVestingToken.test.ts
+++ b/test/MockVestingToken.test.ts
@@ -31,6 +31,8 @@ describe("MockVestingToken Scenarios", function () {
         const globalStartTime = await vestingContract.globalStartTime();
         const cliffEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration);
 
+        // IMPORTANT: There is a 1-second offset with `helpers.time.increaseTo`.
+        // Calling `increaseTo(T)` results in the next block having a timestamp of `T + 1`.
         await helpers.time.increaseTo(cliffEndsTimestamp - 5); // 5 seconds before cliff ends
 
         const releasableAmount = await vestingContract.getCurrentlyReleasableAmount(beneficiary.address);
@@ -91,7 +93,7 @@ describe("MockVestingToken Scenarios", function () {
 
         const schedule = await vestingContract.vestingSchedules(beneficiary.address);
         const globalStartTime = await vestingContract.globalStartTime();
-        const vestingEndsTimestamp = Number(globalStartTime) + Number(schedule.cliffDuration) + Number(schedule.releaseDuration);
+        const vestingEndsTimestamp = Number(globalStartTime) + Number(schedule.totalVestingDuration);
 
         await helpers.time.increaseTo(vestingEndsTimestamp);
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,0 +1,5 @@
+import { ethers } from "hardhat";
+
+export const TOTAL_VESTING_AMOUNT_INVESTOR = ethers.parseUnits("24000000000", 18);
+export const TOTAL_VESTING_AMOUNT_FOUNDER = ethers.parseUnits("20000000000", 18);
+export const TOTAL_VESTING_AMOUNT_EMPLOYEE = ethers.parseUnits("5200000000", 18);


### PR DESCRIPTION
This PR introduces a series of significant improvements to the vesting contract test suite, focusing on enhancing clarity, correctness, and flexibility. The changes address confusing time-based test logic, clean up the codebase, and refactor the mock contract for more robust testing.

The work is based on the following key changes:

1. Refactor and Clarify Vesting Tests
This improves the clarity and robustness of the main vesting tests (Investor, Founder, Employee).
Adds detailed comments to all tests to explain the 1-second offset observed with Hardhat's increaseTo time helper, preventing future confusion.
Refactors vesting period calculations to use the totalVestingDuration variable for better readability.
Removes unused variables from test cases.

2. Remove All Console Logs
This cleans up the entire test suite by removing all console.log statements.
Ensures a clean, professional test output and finalizes the code.

3. Parameterize MockVestingToken
This refactors the MockVestingToken to make its vesting schedule configurable at deployment time.
The constructor now accepts parameters for the vesting schedule (cliff, duration, installments), making it a more flexible tool for testing various scenarios.
This also fixes a critical bug where the mock was incorrectly calculating schedule durations.