### PR TITLE
style(tests): Clean up comments and spacing in vesting token tests

### DIFF
--- a/test/EmployeeVestingToken.test.ts
+++ b/test/EmployeeVestingToken.test.ts
@@ -21,7 +21,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         await vestingContract.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE; // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE; // Total amount for vesting
         await amdToken.connect(owner).transfer(await vestingContract.getAddress(), totalAmdForVesting);
 
         return { vestingContract, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -142,7 +142,7 @@ describe("EmployeeVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20000", 18);
         await vestingContract.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingContract.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE;
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_EMPLOYEE;
         await amdToken
             .connect(owner)
             .transfer(await vestingContract.getAddress(), totalAmdForVesting);

--- a/test/FounderVestingToken.test.ts
+++ b/test/FounderVestingToken.test.ts
@@ -21,7 +21,7 @@ describe("FounderVestingToken Scenarios", function () {
         await vestingToken.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER; // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER; // Total amount for vesting
         await amdToken.connect(owner).transfer(await vestingToken.getAddress(), totalAmdForVesting);
 
         return { vestingToken, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -144,7 +144,7 @@ describe("FounderVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20000", 18);
         await vestingToken.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingToken.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER;
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_FOUNDER;
         await amdToken
             .connect(owner)
             .transfer(await vestingToken.getAddress(), totalAmdForVesting);

--- a/test/InvestorVestingToken.test.ts
+++ b/test/InvestorVestingToken.test.ts
@@ -21,7 +21,7 @@ describe("InvestorVestingToken Scenarios", function () {
         await vestingToken.connect(owner).transfer(beneficiary.address, scheduleAmount);
 
         // Transfer AMD to vesting contract
-        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR; // Example total amount for vesting
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR; // Total amount for vesting
         await amdToken.connect(owner).transfer(await vestingToken.getAddress(), totalAmdForVesting);
 
         return { vestingToken, amdToken, owner, beneficiary, scheduleAmount, amdDecimals };
@@ -147,7 +147,7 @@ describe("InvestorVestingToken Scenarios", function () {
         const scheduleAmount2 = ethers.parseUnits("20002", 18);
         await vestingToken.connect(owner).transfer(beneficiary1.address, scheduleAmount1);
         await vestingToken.connect(owner).transfer(beneficiary2.address, scheduleAmount2);
-                const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR;
+        const totalAmdForVesting = TOTAL_VESTING_AMOUNT_INVESTOR;
         await amdToken
             .connect(owner)
             .transfer(await vestingToken.getAddress(), totalAmdForVesting);


### PR DESCRIPTION
Removes "Example" from comments in EmployeeVestingToken,
FounderVestingToken, and InvestorVestingToken test files for clarity.
 
Also fixes inconsistent spacing to improve code readability.